### PR TITLE
Temporal composite adjust za

### DIFF
--- a/R/ee_temporal_composites.R
+++ b/R/ee_temporal_composites.R
@@ -88,10 +88,11 @@ ee_year_composite.tidyee<-  function(x,
   client_bandnames<- paste0(vrt_band_names(x),"_",stat)
   vrt_summarised <- x$vrt |>
     dplyr::summarise(
-      dates_summarised= list(date),
+      dates_summarised= list(time_start),
       number_images= dplyr::n(),
       time_start= min(.data$time_start),
       time_end= max(.data$time_start),
+      date= lubridate::as_date(time_start),
       .groups = "drop"
     ) |>
     mutate(
@@ -192,10 +193,11 @@ ee_month_composite.tidyee <- function(x, stat, ...){
 
   vrt_summarised <- x$vrt |>
     dplyr::summarise(
-      dates_summarised= list(date),.groups = "drop",
+      dates_summarised= list(.data$time_start),.groups = "drop",
       number_images= dplyr::n(),
       time_start= min(.data$time_start),
-      time_end= max(.data$time_start)
+      time_end= max(.data$time_start),
+      date= lubridate::as_date(time_start)
     ) |>
     mutate(
       band_names = list(client_bandnames)
@@ -283,8 +285,8 @@ ee_year_month_composite.tidyee <-  function(x, stat, ...
 
   # after running the calendarRange maps there is a strange behavior which
   # warrants the need to post-filter.
-  start_post_filter <- lubridate::floor_date(min(x$vrt$date),"month") |> as.character()
-  end_post_filter <- (lubridate::as_date(max(x$vrt$date))+1) |> as.character()
+  start_post_filter <- lubridate::floor_date(min(x$vrt$time_start),"month") |> as.character()
+  end_post_filter <- (lubridate::as_date(max(x$vrt$time_start))+1) |> as.character()
 
 
   years_unique_chr <- unique(x$vrt$year) |> sort()
@@ -369,10 +371,11 @@ ee_year_month_composite.tidyee <-  function(x, stat, ...
   vrt_summarised <- x$vrt |>
     # nest(data=date)
     dplyr::summarise(
-      dates_summarised= list(date),.groups = "drop",
+      dates_summarised= list(.data$time_start),.groups = "drop",
       number_images= dplyr::n(),
-      time_start= min(date),
-      time_end= max(date)
+      time_start= min(.data$time_start),
+      time_end= max(.data$time_start),
+      date= lubridate::as_date(time_start)
     ) |>
     mutate(
       band_names= list(client_bandnames)
@@ -431,6 +434,7 @@ ee_composite.tidyee <-  function(x,
       tidyr::unnest(.data$dates_summarised) |>
       dplyr::summarise(
         time_start= lubridate::ymd(glue::glue("{min_year}-{min_month}-{min_day}")),
+        date= lubridate::as_date(time_start),
         dates_summarised= list(.data$dates_summarised),
         .groups = "drop"
       )
@@ -440,7 +444,8 @@ ee_composite.tidyee <-  function(x,
       # dplyr::tibble() |>
       dplyr::summarise(
         time_start= lubridate::ymd(glue::glue("{min_year}-{min_month}-{min_day}")),
-        dates_summarised= list(date),
+        date= lubridate::as_date(time_start),
+        dates_summarised= list(time_start),
         .groups = "drop"
       )
   }

--- a/R/ee_temporal_composites.R
+++ b/R/ee_temporal_composites.R
@@ -323,15 +323,21 @@ ee_year_month_composite.tidyee <-  function(x, stat, ...
         indexString <-  yearString$cat(monthString)
         idString <- ee$String("composited_yyyymmm_")$cat(indexString)
         ic_temp_filtered <- yearCollection$filter(rgee::ee$Filter$calendarRange(m, m, 'month'))
-        ee_reducer(ic_temp_filtered)$
-          # set('system:id',idString)$
-          set('system:index', indexString)$
-          set('year',y)$
-          set('month',m)$
-          set('date',rgee::ee$Date$fromYMD(y,m,1))$
-           #set('system:time_start',ee$Date$fromYMD(y,m,1))$
-          set('system:time_start',rgee::ee$Date$millis(start_date))$
-          set('system:time_end',rgee::ee$Date$millis(end_date))
+        rgee::ee$Algorithms$If(
+          ic_temp_filtered$size(),
+          ee_reducer(ic_temp_filtered)$
+            # set('system:id',idString)$
+            set('system:index', indexString)$
+            set('year',y)$
+            set('month',m)$
+            set('date',rgee::ee$Date$fromYMD(y,m,1))$
+            #set('system:time_start',ee$Date$fromYMD(y,m,1))$
+            set('system:time_start',rgee::ee$Date$millis(start_date))$
+            set('system:time_end',rgee::ee$Date$millis(end_date)),
+          NULL
+
+        )
+
 
       }))
     )

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -120,7 +120,7 @@ summarise_pixels <-  function(.data,stat,...){
         ~ee_composite(
           .x |>
           group_by(!!!rlang::syms(group_vars_chr)),
-          stat="sum")
+          stat=stat)
         ) |>
       bind_ics()
     #previously would just call this:

--- a/tests/testthat/test-year_month_composite.R
+++ b/tests/testthat/test-year_month_composite.R
@@ -1,0 +1,33 @@
+skip_if_no_pypkg()
+test_that("year_month_composite; issue #28", {
+
+  geom <- ee$Geometry$Polygon(list(
+    c(44.2354847930793, 34.83077069846819),
+    c(44.261577322376176, 34.692001577255105),
+    c(44.40851946104805, 34.511140220037795),
+    c(44.607646658313676, 34.47152432533435),
+    c(44.687297537219926, 34.58918498051208),
+    c(44.5211293243293, 34.75069665768057),
+    c(44.393413259876176, 34.810477595189816),
+    c(44.28217668761055, 34.88598770009403),
+    c(44.223125173938676, 34.84316957807562)
+  ))
+
+  l8_ic <-  ee$ImageCollection('LANDSAT/LC08/C02/T1_L2')$
+    filterDate("2013-01-01","2022-12-31")$
+    filterBounds(geom)$
+    filter(ee$Filter$lt('CLOUD_COVER', 25))
+
+  l8_ic_tidy <-   as_tidyee(l8_ic)
+
+
+  l8_median_compsites <- l8_ic_tidy |>
+    group_by(year, month) |>
+    summarise(
+      stat="median"
+    )
+
+  # this is not good they should be the same
+  expect_equal(l8_median_compsites$ee_ob$size()$getInfo(),l8_median_compsites$vrt|> nrow())
+
+})


### PR DESCRIPTION
fixed issue: https://github.com/r-tidy-remote-sensing/tidyrgee/issues/28 so far no problems.

Additionally, I also just pushed some general house-keeping/standardization adjustments to the `temporal_composite` functions. After using the package a bit - I feel like all composites `vrt`s should have both a `time_start` column and a `date` column. The `time_start` should always exactly match the `ic$aggregate_arrary("system:time_start")`. date & time_start can differ inthe case where `time_start` is a datetime